### PR TITLE
Update ddev-kubernetes dependency reference

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -7,7 +7,7 @@ project_files:
   - config.tsh.yaml
 
 dependencies:
-  - ddev-kubernetes
+  - MurzNN/ddev-kubernetes
 
 ddev_version_constraint: '>= v1.24.3'
 


### PR DESCRIPTION
In upcoming DDEV version v1.24.8, `ddev add-on get` will try to download dependencies, so the `dependencies` list has to show where the dependencies can come from. Please pull this and make a new release, thanks!

