### PR TITLE
Add existence checks for .env.web and variables

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -34,7 +34,7 @@ pre_install_actions:
   # Get CUSTOMER_NAME from user if we don't have it yet
   - |
     #ddev-nodisplay
-    if [ "$(ddev dotenv get .ddev/.env.web --customer-name)" != "" ]; then
+    if [ -f .ddev/.env.web ] && [ "$(ddev dotenv get .ddev/.env.web --customer-name)" != "" ]; then
       echo "Using existing CUSTOMER_NAME from .env.web."
     else
       printf "\n\nPlease enter your customer name (like 'my-example'): "
@@ -43,7 +43,7 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Setting CUSTOMER_NAME
-    if [ "$(ddev dotenv get .ddev/.env.web --customer-name)" = "" ]; then
+    if [ ! -f .ddev/.env.web ] || [ "$(ddev dotenv get .ddev/.env.web --customer-name)" = "" ]; then
       read customer_name
       echo "customer_name = '${customer_name}'"
       ddev dotenv set .ddev/.env.web --customer-name=${customer_name}
@@ -52,7 +52,7 @@ pre_install_actions:
   # Get TELEPORT_BASE from user if we don't have it yet
   - |
     #ddev-nodisplay
-    if [ "$(ddev dotenv get .ddev/.env.web --teleport-base)" != "" ]; then
+    if ddev dotenv get .ddev/.env.web --teleport-base >/dev/null 2>&1 && [ "$(ddev dotenv get .ddev/.env.web --teleport-base)" != "" ]; then
       echo "Using existing TELEPORT_BASE from .env.web."
     else
       printf "\n\nPlease enter your Teleport base domain (like 'teleport.example.com'): "
@@ -61,7 +61,7 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Set TELEPORT_BASE
-    if [ "$(ddev dotenv get .ddev/.env.web --teleport-base)" = "" ]; then
+    if ! ddev dotenv get .ddev/.env.web --teleport-base >/dev/null 2>&1 || [ "$(ddev dotenv get .ddev/.env.web --teleport-base 2>/dev/null)" = "" ]; then
       read teleport_base
       echo "teleport_base = '${teleport_base}'"
       ddev dotenv set .ddev/.env.web --teleport-base=${teleport_base}
@@ -70,7 +70,7 @@ pre_install_actions:
   # Get KUBE_CLUSTER_BASE from user if we don't have it yet
   - |
     #ddev-nodisplay
-    if [ "$(ddev dotenv get .ddev/.env.web --kube-cluster-base)" != "" ]; then
+    if ddev dotenv get .ddev/.env.web --kube-cluster-base >/dev/null 2>&1 && [ "$(ddev dotenv get .ddev/.env.web --kube-cluster-base)" != "" ]; then
       echo "Using existing KUBE_CLUSTER_BASE from .env.web."
     else
       printf "\n\nPlease enter your Kubernetes cluster base (like 'example-cluster'): "
@@ -79,7 +79,7 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Set KUBE_CLUSTER_BASE
-    if [ "$(ddev dotenv get .ddev/.env.web --kube-cluster-base)" = "" ]; then
+    if ! ddev dotenv get .ddev/.env.web --kube-cluster-base >/dev/null 2>&1 || [ "$(ddev dotenv get .ddev/.env.web --kube-cluster-base 2>/dev/null)" = "" ]; then
       read kube_cluster_base
       echo "kube_cluster_base = '${kube_cluster_base}'"
       ddev dotenv set .ddev/.env.web --kube-cluster-base=${kube_cluster_base}

--- a/install.yaml
+++ b/install.yaml
@@ -34,7 +34,7 @@ pre_install_actions:
   # Get CUSTOMER_NAME from user if we don't have it yet
   - |
     #ddev-nodisplay
-    if [ -f .ddev/.env.web ] && [ "$(ddev dotenv get .ddev/.env.web --customer-name)" != "" ]; then
+    if [ -f .ddev/.env.web ] && [ "$(ddev dotenv get .ddev/.env.web --customer-name 2>/dev/null)" != "" ]; then
       echo "Using existing CUSTOMER_NAME from .env.web."
     else
       printf "\n\nPlease enter your customer name (like 'my-example'): "
@@ -43,7 +43,7 @@ pre_install_actions:
   - |
     #ddev-nodisplay
     #ddev-description:Setting CUSTOMER_NAME
-    if [ ! -f .ddev/.env.web ] || [ "$(ddev dotenv get .ddev/.env.web --customer-name)" = "" ]; then
+    if [ ! -f .ddev/.env.web ] || ! ddev dotenv get .ddev/.env.web --customer-name >/dev/null 2>&1 || [ "$(ddev dotenv get .ddev/.env.web --customer-name 2>/dev/null)" = "" ]; then
       read customer_name
       echo "customer_name = '${customer_name}'"
       ddev dotenv set .ddev/.env.web --customer-name=${customer_name}


### PR DESCRIPTION
## The Issue

- Fixes #8 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

The problem was that ddev dotenv get throws an error when a variable doesn't exist in the file, rather than returning an empty string.

The fix uses `ddev dotenv get .ddev/.env.web --teleport-base >/dev/null 2>&1` to check if the command succeeds (exit code 0) before trying to get the value. If the command fails (variable doesn't exist) or returns an empty string, it will prompt the user for input.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/froboy/ddev-tsh/tarball/refs/pull/8/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
