### PR TITLE
1Password automated login

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ As always, after install or modifying any config, run:
 
 ## Usage
 
-| Command          | Description                                                                       |
-|------------------|-----------------------------------------------------------------------------------|
-| `ddev tsh`       | Passthrough for the [tsh](https://goteleport.com/docs/reference/cli/tsh/) command |
-| `ddev tsh-login` | Log in to a Teleport server and connect to a k8s cluster.                         |
+| Command                 | Description                                                                              |
+|-------------------------|------------------------------------------------------------------------------------------|
+| `ddev tsh`              | Passthrough for the [tsh](https://goteleport.com/docs/reference/cli/tsh/) command        |
+| `ddev tsh-login [<env>]`| Log in to a Teleport server and connect to a k8s cluster (interactive prompt by default).|
+| `ddev tsh-login --op [<env>]` | Same, but pulls password + TOTP from 1Password for unattended login.   |
 
 ## Advanced Customization
 

--- a/commands/host/tsh-login
+++ b/commands/host/tsh-login
@@ -87,4 +87,4 @@ fi
 
 WEB_ENV=()
 [ "$USE_OP" = "1" ] && WEB_ENV=(env DDEV_TSH_SKIP_LOGIN=1)
-ddev exec "${WEB_ENV[@]}" bash /mnt/ddev_config/commands/web/tsh-login "${POSITIONAL[@]}"
+ddev exec "${WEB_ENV[@]+"${WEB_ENV[@]}"}" bash /mnt/ddev_config/commands/web/tsh-login "${POSITIONAL[@]+"${POSITIONAL[@]}"}"

--- a/commands/host/tsh-login
+++ b/commands/host/tsh-login
@@ -29,7 +29,7 @@ Continuing without 1Password — \`tsh\` will prompt for password and OTP.
 EOF
     USE_OP=0
   else
-    OP_PASSWORD_REF="${DDEV_TSH_OP_PASSWORD_REF:-op://Private/Teleport/password}"
+    OP_PASSWORD_REF="${DDEV_TSH_OP_PASSWORD_REF:-op://Employee/Teleport/password}"
     OP_OTP_ITEM="${DDEV_TSH_OP_OTP_ITEM:-Teleport}"
     if ! OP_PW=$(op read "$OP_PASSWORD_REF" 2>/dev/null) \
        || ! OP_OTP=$(op item get "$OP_OTP_ITEM" --otp 2>/dev/null) \
@@ -39,16 +39,16 @@ EOF
 
 To enable unattended login, set up a 1Password item that tsh-login can read:
   1. Sign in to the CLI:           op signin
-  2. Create a Login item named 'Teleport' in your Private vault, with:
+  2. Create a Login item named 'Teleport' in your Employee vault, with:
        - password field   : your Teleport password
        - one-time password: scan/paste the Teleport TOTP secret (so 'op item get Teleport --otp' returns a 6-digit code)
   3. Verify:
-       op read 'op://Private/Teleport/password'
+       op read 'op://Employee/Teleport/password'
        op item get Teleport --otp
 
-If your item lives elsewhere, override the defaults via env vars:
-  DDEV_TSH_OP_PASSWORD_REF   default: op://Private/Teleport/password
-  DDEV_TSH_OP_OTP_ITEM       default: Teleport
+If your item lives elsewhere, override the defaults by setting these in your shell profile (~/.zshrc, ~/.bashrc, etc.):
+  export DDEV_TSH_OP_PASSWORD_REF="op://Vault/Item/password"
+  export DDEV_TSH_OP_OTP_ITEM="ItemName"
 EOF
       USE_OP=0
     fi

--- a/commands/host/tsh-login
+++ b/commands/host/tsh-login
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#ddev-generated
+
+## Description: Log in to Teleport and connect to the project Kubernetes cluster. Pass --op to pull password + TOTP from 1Password for unattended login.
+## Usage: tsh-login [--op] [<env>]
+## Example: "ddev tsh-login --op dev"
+## Flags: [{"Name":"op","Usage":"pull Teleport password + TOTP from 1Password (host 'op' CLI) and drive tsh unattended","Type":"bool"}]
+## ExecRaw: false
+
+# With --op, this wrapper reads pw+TOTP from the host's 1Password CLI and drives `tsh login` via expect inside the container; the kube login + verify steps are delegated to the web `tsh-login` command (which also runs the whole flow on its own when --op is absent). DDEV_TSH_OP_PASSWORD_REF / DDEV_TSH_OP_OTP_ITEM override the 1Password item refs. Remove #ddev-generated above to make local edits stick.
+
+set -euo pipefail
+
+USE_OP=0
+POSITIONAL=()
+for arg in "$@"; do
+  case "$arg" in
+    --op) USE_OP=1 ;;
+    *)    POSITIONAL+=("$arg") ;;
+  esac
+done
+
+if [ "$USE_OP" = "1" ]; then
+  if ! command -v op >/dev/null 2>&1; then
+    cat >&2 <<EOF
+--op requested but the 1Password CLI ('op') is not installed on the host.
+Install it from https://developer.1password.com/docs/cli/get-started/ and run \`op signin\`, then retry.
+Continuing without 1Password — \`tsh\` will prompt for password and OTP.
+EOF
+    USE_OP=0
+  else
+    OP_PASSWORD_REF="${DDEV_TSH_OP_PASSWORD_REF:-op://Private/Teleport/password}"
+    OP_OTP_ITEM="${DDEV_TSH_OP_OTP_ITEM:-Teleport}"
+    if ! OP_PW=$(op read "$OP_PASSWORD_REF" 2>/dev/null) \
+       || ! OP_OTP=$(op item get "$OP_OTP_ITEM" --otp 2>/dev/null) \
+       || [ -z "$OP_PW" ] || [ -z "$OP_OTP" ]; then
+      cat >&2 <<EOF
+--op requested but the 1Password lookup failed. Continuing without 1Password — \`tsh\` will prompt for password and OTP.
+
+To enable unattended login, set up a 1Password item that tsh-login can read:
+  1. Sign in to the CLI:           op signin
+  2. Create a Login item named 'Teleport' in your Private vault, with:
+       - password field   : your Teleport password
+       - one-time password: scan/paste the Teleport TOTP secret (so 'op item get Teleport --otp' returns a 6-digit code)
+  3. Verify:
+       op read 'op://Private/Teleport/password'
+       op item get Teleport --otp
+
+If your item lives elsewhere, override the defaults via env vars:
+  DDEV_TSH_OP_PASSWORD_REF   default: op://Private/Teleport/password
+  DDEV_TSH_OP_OTP_ITEM       default: Teleport
+EOF
+      USE_OP=0
+    fi
+  fi
+fi
+
+if [ "$USE_OP" = "1" ]; then
+  # Spinner during the silent-prompt window inside the expect helper.
+  SPIN=""
+  spin_cleanup() {
+    if [ -n "$SPIN" ] && kill -0 "$SPIN" 2>/dev/null; then
+      kill "$SPIN" 2>/dev/null || true
+      while kill -0 "$SPIN" 2>/dev/null; do :; done
+    fi
+  }
+  if [ -t 2 ]; then
+    (
+      trap 'printf "\r\033[K" >&2; exit 0' TERM INT
+      chars='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'; i=0
+      while :; do
+        printf '\r\033[K%s logging in to Teleport...' "${chars:$((i%10)):1}" >&2
+        i=$((i+1)); sleep 0.1
+      done
+    ) &
+    SPIN=$!
+    trap 'spin_cleanup' EXIT INT TERM
+  fi
+  printf '%s\n%s\n' "$OP_PW" "$OP_OTP" | ddev exec \
+    expect -f /mnt/ddev_config/tsh-login-pty-helper.exp 2>&1 | (
+      first=$(dd bs=1 count=1 2>/dev/null) || true
+      spin_cleanup
+      printf '%s' "$first"
+      cat
+    )
+fi
+
+WEB_ENV=()
+[ "$USE_OP" = "1" ] && WEB_ENV=(env DDEV_TSH_SKIP_LOGIN=1)
+ddev exec "${WEB_ENV[@]}" bash /mnt/ddev_config/commands/web/tsh-login "${POSITIONAL[@]}"

--- a/commands/web/tsh-login
+++ b/commands/web/tsh-login
@@ -55,7 +55,9 @@ fi
 
 # These variables don't need to be specified since they already exist as
 # environment variables in the web container, but we set them here for clarity.
-tsh login --proxy=${TELEPORT_PROXY} --user=${TELEPORT_USER} ${TELEPORT_CLUSTER}
+if [ "${DDEV_TSH_SKIP_LOGIN:-0}" != "1" ]; then
+  tsh login --proxy=${TELEPORT_PROXY} --user=${TELEPORT_USER} ${TELEPORT_CLUSTER}
+fi
 
 tsh kube login "$KUBE_CLUSTER_VALUE"
 

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,8 @@ name: tsh
 project_files:
   - commands/web/tsh
   - commands/web/tsh-login
+  - commands/host/tsh-login
+  - tsh-login-pty-helper.exp
   - web-build/Dockerfile.tsh
   - config.tsh.yaml
 

--- a/tsh-login-pty-helper.exp
+++ b/tsh-login-pty-helper.exp
@@ -1,0 +1,63 @@
+#!/usr/bin/expect -f
+# ddev-generated - drives `tsh login` with creds read from stdin (pw\notp\n).
+#   - env: TELEPORT_PROXY, TELEPORT_USER, TELEPORT_CLUSTER (already set in the web container)
+#   - stdin: two lines, pw then otp
+#   - exits with tsh's status
+
+set timeout 30
+
+foreach var {TELEPORT_PROXY TELEPORT_USER TELEPORT_CLUSTER} {
+    if {![info exists env($var)] || $env($var) eq ""} {
+        puts stderr "$var is empty in the web container env. Aborting."
+        exit 2
+    }
+}
+set proxy   $env(TELEPORT_PROXY)
+set user    $env(TELEPORT_USER)
+set cluster $env(TELEPORT_CLUSTER)
+
+# Secrets via stdin so they never touch argv/env.
+gets stdin pw
+gets stdin otp
+if {$pw eq "" || $otp eq ""} {
+    puts stderr "password and OTP must be provided on stdin (two lines)"
+    exit 2
+}
+
+# Strip terminal queries (OSC ...(BEL|ST) and CSI ...n) so the terminal doesn't
+# reply with bytes that surface on screen via the tty echo.
+proc filter {s} {
+    regsub -all -- {\x1b\][^\x07\x1b]*(\x07|\x1b\\)} $s "" s
+    regsub -all -- {\x1b\[\??\d*(;\d+)*n} $s "" s
+    return $s
+}
+proc dump_filtered {} {
+    global expect_out
+    if {[info exists expect_out(buffer)]} {
+        puts -nonewline [filter $expect_out(buffer)]
+        flush stdout
+    }
+}
+
+# Silent during the credential-driving phase so query bytes don't leak out.
+log_user 0
+
+spawn -noecho tsh login --proxy=$proxy --user=$user --auth=local --mfa-mode=otp $cluster
+
+expect {
+    -nocase -re "password:?\\s*" { send -- "$pw\r" }
+    timeout                       { dump_filtered; puts stderr "\ntimeout waiting for password prompt"; exit 1 }
+    eof                           { dump_filtered; catch wait r; exit [lindex $r 3] }
+}
+
+expect {
+    -nocase -re "(otp|token|code):?\\s*" { send -- "$otp\r" }
+    timeout                               { dump_filtered; puts stderr "\ntimeout waiting for otp prompt"; exit 1 }
+    eof                                   { dump_filtered; catch wait r; exit [lindex $r 3] }
+}
+
+# Post-auth output (success message, kube login results) shows live.
+log_user 1
+expect eof
+catch wait result
+exit [lindex $result 3]

--- a/web-build/Dockerfile.tsh
+++ b/web-build/Dockerfile.tsh
@@ -7,17 +7,22 @@
 ## client/proxy skew bugs (e.g. 18.7.x client against an 18.6.x proxy caused
 ## `kubectl cp` stream corruption against EKS kube agents in our environment).
 
+# `expect` installed up front so users get the
+# 1Password-driven auto-login out of the box without webimage_extra_packages.
+RUN apt-get update && apt-get install -y --no-install-recommends expect \
+  && rm -rf /var/lib/apt/lists/*
+
 # Temporary switch to the ddev user to install utils in the userspace.
 USER $uid
 
 ARG TELEPORT_PROXY=${TELEPORT_PROXY}
 
 RUN if [ -n "${TELEPORT_PROXY}" ]; then \
-    TELEPORT_VERSION="$(curl -fsSL --connect-timeout 5 "https://${TELEPORT_PROXY}/webapi/ping" | grep -o '"server_version":"[^"]*"' | cut -d'"' -f4)"; \
-    echo "Installing Teleport ${TELEPORT_VERSION} (matching proxy ${TELEPORT_PROXY})"; \
+  TELEPORT_VERSION="$(curl -fsSL --connect-timeout 5 "https://${TELEPORT_PROXY}/webapi/ping" | grep -o '"server_version":"[^"]*"' | cut -d'"' -f4)"; \
+  echo "Installing Teleport ${TELEPORT_VERSION} (matching proxy ${TELEPORT_PROXY})"; \
   else \
-    TELEPORT_VERSION="$(curl -fsSL https://api.github.com/repos/gravitational/teleport/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"v?([0-9.]+)\".*/\1/')"; \
-    echo "Installing Teleport ${TELEPORT_VERSION} (latest; no proxy configured)"; \
+  TELEPORT_VERSION="$(curl -fsSL https://api.github.com/repos/gravitational/teleport/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"v?([0-9.]+)\".*/\1/')"; \
+  echo "Installing Teleport ${TELEPORT_VERSION} (latest; no proxy configured)"; \
   fi \
   && TELEPORT_EDITION="oss" \
   && curl -fsSL https://cdn.teleport.dev/install.sh | bash -s "${TELEPORT_VERSION?}" "${TELEPORT_EDITION?}"


### PR DESCRIPTION
## The feature

Manual login process user experience could be optionally improved with 1Password manager integration.

Provides additional argument "--op" to the command:
`ddev tsh-login --op dev`

## How This PR Solves The Issue

Adds a host command along with for web command. This host command calls `op` program(1Password official CLI). After user authorization it receives password and OTP from 1Password. Then it calls `expect` program defined in `tsh-login-pty-helper.exp` inside web container to pass those credentials into `tsh login`.

This whole code path activated only if `--op` argument is provided. In other case classic web command `tsh-login` is called. 

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/froboy/ddev-tsh/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
ddev tsh-login --op dev
```